### PR TITLE
Target Group Unhealthy Check

### DIFF
--- a/supporting_material/servers.yml
+++ b/supporting_material/servers.yml
@@ -33,8 +33,8 @@ Resources:
           !Sub "${EnvironmentName}-VPCID"
       SecurityGroupIngress:
       - IpProtocol: tcp
-        FromPort: 8080
-        ToPort: 8080
+        FromPort: 80
+        ToPort: 80
         CidrIp: 0.0.0.0/0
       - IpProtocol: tcp
         FromPort: 22
@@ -115,7 +115,7 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 8
       HealthyThresholdCount: 2
-      Port: 8080
+      Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 5
       VpcId: 


### PR DESCRIPTION
Apache by default work on port 80 so Target group will always fail the check on port 8080
another solution for it to work is to configure Apache to listen to port 8080 or deploy docker container which map 8080:80