### PR TITLE
Update Lucidchart.com link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You would require to have an AWS account to be able to build cloud infrastructur
 An editor would be helpful to visualize the image as well as code. Download the VS Code editor [here](https://code.visualstudio.com/download).
 
 ##### 3. An account on www.lucidchart.com
-A free user-account on [www.lucidchart.com](www.lucidchart.com) is required to be able to draw the web app architecture diagrams for AWS.
+A free user-account on [www.lucidchart.com](https://www.lucidchart.com/) is required to be able to draw the web app architecture diagrams for AWS.
 
 
 ### How to run the supporting material?


### PR DESCRIPTION
in the previous version when clicking the Lucidchart link, it referred to (https://github.com/udacity/nd9991-c2-Infrastructure-as-Code-v1/blob/master/www.lucidchart.com), which is an invalid link. I just fixed this issue :+1:  👀